### PR TITLE
#162452710 rename routes

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-DB=sjkkkkks

--- a/README.md
+++ b/README.md
@@ -46,12 +46,23 @@ resolved).
 - `Node.js`
 - `Express framework`
 
+## UI link (Gh-pages): 
+ `https://davdwhyte87.github.io/iReporter/UI/`
+
+ ## Pivotal Tracker board
+ `https://www.pivotaltracker.com/n/projects/2226785`
+
 ## Api Endpoints
-- `GET /api/v1/record` - Fetches all the records
-- `GET /api/v1/record/:id` - Fetches a single record
-- `POST /api/v1/record` - Creates a record
-- `PATCH /api/v1/record/:id` - Edits a record
-- `DELETE /api/v1/record/:id` - Deletes a record
+- `GET /api/v1/red-flag` - Fetches all the red-flag records
+- `GET /api/v1/intervention` - Fetches all the intervention records
+- `GET /api/v1/red-flag/:id` - Fetches a single record
+- `GET /api/v1/intervention/:id` - Fetches a single record
+- `POST /api/v1/red-flag` - Creates a red-flag record
+- `POST /api/v1/intervention` - Creates an intervention record
+- `PATCH /api/v1/red-flag/:id` - Edits a red-flag record
+- `PATCH /api/v1/intervention/:id` - Edits an intervention record
+- `DELETE /api/v1/red-flag/:id` - Deletes a red-flag record
+- `DELETE /api/v1/intervention/:id` - Deletes an intervention record
  
  ## Known issues
 - The views are just built out, they have no functionalities yet

--- a/api/db/db.js
+++ b/api/db/db.js
@@ -17,7 +17,7 @@ const createTables = () => {
         created_by integer NOT NULL,
         type varchar(100) NOT NULL,
         location varchar(100),
-        status integer,
+        status varchar(100),
         image TEXT
     );
     `;

--- a/api/models/Record.js
+++ b/api/models/Record.js
@@ -28,11 +28,11 @@ const createRecordDB = async (record) => {
     return pool.query(createQuery, values);
 };
 
-const getAllRecordsDB= async () => {
+const getAllRecordsDB= async (selector) => {
     const getRecordsQuery=`
-    SELECT * FROM records 
+    SELECT * FROM records WHERE type=$1 
     `;
-    return pool.query(getRecordsQuery);
+    return pool.query(getRecordsQuery, selector);
 };
 
 const getSingleRecordDB= async (selector) => {
@@ -51,5 +51,13 @@ const updateRecordsDB= async (record) => {
     return pool.query(Query, values);
 };
 
+const deleteRecordDB= async (selector) => {
+    const Query=`
+    DELETE FROM records WHERE id=$1 
+    `;
+    return pool.query(Query, selector);
+};
 
-export { Record, DbRecord, createRecordDB, getAllRecordsDB, getSingleRecordDB, updateRecordsDB };
+
+export { Record, DbRecord, createRecordDB, getAllRecordsDB,
+     getSingleRecordDB, updateRecordsDB, deleteRecordDB };

--- a/api/routes/record.js
+++ b/api/routes/record.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import { validate, create, getAll, getSingle, updateRecord, deleteRecord } from '../controllers/record';
 import { Record } from '../models/Record';
+import { stringify } from 'querystring';
 
 const recordRouter=express.Router();
 

--- a/app.js
+++ b/app.js
@@ -17,7 +17,8 @@ app.use((req, res, next) => {
 const apiv='/api/v1';
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
-app.use(apiv+'/record', recordRouter);
+app.use(apiv+'/red-flag', recordRouter);
+app.use(apiv+'/intervention', recordRouter);
 app.get('/api/v1', (req, res) => {
     res.status(200).send('Hey this is the iReporter API version 1');
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4111,9 +4111,9 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
-      "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+      "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.0.0",
@@ -4127,23 +4127,23 @@
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
         "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
+        "strip-ansi": "^5.0.0",
         "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
           "dev": true
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.0.0"
           }
         }
       }
@@ -5705,9 +5705,9 @@
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
-      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.2.tgz",
+      "integrity": "sha512-/OLz5F9beZUWwSHZDreXgap1XShX6W+DCHQCqwCF7uZ88s6uTlD2cR3JBE77SegCmNtb1Idst+NfmwcdU6KVhw==",
       "dev": true
     },
     "proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "chai": "^4.1.2",
     "chai-http": "^4.2.0",
     "coveralls": "^3.0.2",
-    "eslint": "5.5.0",
+    "eslint": "^5.5.0",
     "eslint-config-airbnb-base": "13.1.0",
     "eslint-plugin-import": "2.14.0",
     "istanbul": "^0.4.5",

--- a/test/record.js
+++ b/test/record.js
@@ -8,7 +8,7 @@ const should=chai.should();
 let ExampleRecordId=null;
 
 describe('Tests for records ', () => {
-    it('should create a record', (done) => {
+    it('should create a red-flag record', (done) => {
         const record={
             title: 'We need water in apata!',
             type: 'intervention ',
@@ -16,7 +16,25 @@ describe('Tests for records ', () => {
             created_by: 4,
             status: 'under-investigation',
         };
-        chai.request(app).post('/api/v1/record').send(record)
+        chai.request(app).post('/api/v1/red-flag').send(record)
+        .end((err, res) => {
+            res.should.have.status(200);
+            res.should.be.a('object');
+            res.body.should.have.property('data');
+            res.body.data.should.have.property('title');
+            ExampleRecordId=res.body.data.id;
+            done();
+        });
+    });
+    it('should create an intervention record', (done) => {
+        const record={
+            title: 'We need water in apata!',
+            type: 'intervention ',
+            comment: 'tsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad k',
+            created_by: 4,
+            status: 'under-investigation',
+        };
+        chai.request(app).post('/api/v1/intervention').send(record)
         .end((err, res) => {
             res.should.have.status(200);
             res.should.be.a('object');
@@ -32,7 +50,7 @@ describe('Tests for records ', () => {
             comment: 'tsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad ktsgshh sjhkaj hkaj hkah ka hdkja sdhkja dhkja dhka dhkaj jkadjad k',
             status: 'under-investigation',
         };
-        chai.request(app).post('/api/v1/record').send(record)
+        chai.request(app).post('/api/v1/red-flag').send(record)
         .end((err, res) => {
             res.should.have.status(404);
             res.should.be.a('object');
@@ -49,7 +67,7 @@ describe('Tests for records ', () => {
             created_by: 4,
             status: 'under-investigation',
         };
-        chai.request(app).post('/api/v1/record').send(record)
+        chai.request(app).post('/api/v1/red-flag').send(record)
         .end((err, res) => {
             res.should.have.status(404);
             res.should.be.a('object');
@@ -59,8 +77,8 @@ describe('Tests for records ', () => {
         });
     });
 
-    it('should get all the records in the database', (done) => {
-        chai.request(app).get('/api/v1/record')
+    it('should get all the red-flag records in the database', (done) => {
+        chai.request(app).get('/api/v1/red-flag')
         .end((err, res) => {
             res.should.have.status(200);
             res.should.be.a('object');
@@ -71,7 +89,7 @@ describe('Tests for records ', () => {
     });
 
     it('should get a single record', (done) => {
-        chai.request(app).get('/api/v1/record/'+ExampleRecordId)
+        chai.request(app).get('/api/v1/red-flag/'+ExampleRecordId)
         .end((err, res) => {
             res.should.have.status(200);
             res.should.be.a('object');
@@ -81,11 +99,49 @@ describe('Tests for records ', () => {
         });
     });
     it('should not get a single record if it does not exists', (done) => {
-        chai.request(app).get('/api/v1/record/'+ExampleRecordId+99302)
+        chai.request(app).get('/api/v1/red-flag/'+ExampleRecordId+99302)
         .end((err, res) => {
             res.should.have.status(404);
             res.should.be.a('object');
             res.body.should.have.property('error');
+            done();
+        });
+    });
+
+    it('should update a record', (done) => {
+        const record={
+            title: 'Danie is actually buharri',
+            location: '172.39 293.289',
+            status: 3,
+        };
+        chai.request(app).patch('/api/v1/red-flag/'+ExampleRecordId).send(record)
+        .end((err, res) => {
+            res.should.have.status(200);
+            res.should.be.a('object');
+            res.body.should.have.property('data');
+            done();
+        });
+    });
+    it('should not update a record with a wrong id', (done) => {
+        const record={
+            title: 'Danie is actually buharri',
+            location: '172.39 293.289',
+            status: 3,
+        };
+        chai.request(app).patch('/api/v1/red-flag/'+ExampleRecordId+98989).send(record)
+        .end((err, res) => {
+            res.should.have.status(404);
+            res.should.be.a('object');
+            res.body.should.have.property('error');
+            done();
+        });
+    });
+    it('should delete a record', (done) => {
+        chai.request(app).del('/api/v1/red-flag/'+ExampleRecordId)
+        .end((err, res) => {
+            res.should.have.status(200);
+            res.should.be.a('object');
+            res.body.should.have.property('data');
             done();
         });
     });


### PR DESCRIPTION
**What does this PR do ?**
This pull request renames the routes from `api/v1/record` to `api/v1/red-flag` and `api/v1/intervention` 

**Description of task to be completed?**
- rename endpoints
- maintain single model for records
- write tests for the new end points

**How can this be manually tested?**
- clone the repo
- cd into the project directory
- run npm i to install dependencies
- run npm start to start the server
- use the api endpoints in the readme to test the new endpoints

**Relevant pivotal tracker stories?**
`162452710`