### PR TITLE
#163350640 Bug: increate api payload size

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,8 +19,8 @@ app.use((req, res, next) => {
 });
 
 
-app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: false, limit: '10mb' }));
+app.use(bodyParser.json({ limit: '10mb' }));
 app.use('/api/v1/red-flags', recordRouter);
 app.use('/api/v1/interventions', recordRouter);
 app.use('/api/v1/auth', authRouter);


### PR DESCRIPTION
**What does this PR do?**
This PR enables users to upload data as payload to the api of over 9mb and a limit of 10mb

**Tasks to be completed?**
- reconfigure body-parser for json requests to take in more data

**How can this be manually tested?**
- clone the repo
- cd into the directory
- install node js and postgres
- create database `irepoter`
- create  .env from example.env
- run npm i
- run npm start
- send a POST request to `/api/v1/interventions` with an encoded 3mb image 

**Relevant PT story?**
`163350640`