### PR TITLE
#163395374  Add admin change status

### DIFF
--- a/UI/css/style.css
+++ b/UI/css/style.css
@@ -532,5 +532,10 @@ body {
 
 	.nav-mobile {
 		display: block;
-  	}
+		}
+	.hero {
+		height: 100%;
+		padding: 0px;
+		background-attachment: unset;
+	}
 }

--- a/UI/js/records.js
+++ b/UI/js/records.js
@@ -109,7 +109,7 @@ function getData() {
 function recordTemplate(currentData) {
   return `
   <div class="card col-3">
-  <p class="record-status">Status: ${currentData.status} ${user.isAdmin?'<a href=""><i class="fa fa-fw fa-edit"></i></a>':''}</p> 
+  <p class="record-status">Status: ${currentData.status} ${user.isAdmin?'<a href="#"><i class="fa fa-fw fa-edit"></i></a>':''}</p> 
   ${ currentData.image?` <img class="record-image" src="${currentData.image}"/>`:''}
   <a href="single-record.html" class="record-title" onClick="setViewSingle(event)" data="${currentData.id}">${currentData.title}</a>
   <div class="record-actions">

--- a/UI/js/single-record.js
+++ b/UI/js/single-record.js
@@ -82,13 +82,63 @@ function getData() {
 }
 
 
+
+function changeStatus(e) {
+  e.preventDefault();
+  const elementClicked = e.target;
+  const newStatus = elementClicked.options[elementClicked.selectedIndex].value;
+  console.log(newStatus);
+  const currentId = elementClicked.getAttribute('data');
+  const recordType = elementClicked.getAttribute('type');
+  console.log(recordType);
+  elementClicked.setAttribute('disabled', 'true');
+  let url = "https://ireporterx.herokuapp.com/api/v1/red-flags/"+currentId+'/status';
+  if (recordType == 'intervention') {
+    url = "https://ireporterx.herokuapp.com/api/v1/interventions/"+currentId+'/status';
+  }
+  
+  const data= {
+    status: newStatus
+};
+  fetch(url, {
+    method: "PATCH",
+    headers: {
+        'Content-Type': 'application/json',
+        'token': localStorage.getItem('token')
+      },
+      body: JSON.stringify(data),
+  }).then(res => res.json())
+  .then(response => {
+    elementClicked.removeAttribute('disabled', 'false');
+    console.log(elementClicked);
+    if (response.status === 400) {
+      if (typeof response.error === 'string' || response.error instanceof String) {
+          flashMessage('error', response.error);  
+      } else {
+          flashMessage('errorlist', 'Error updating location', response.error);
+      }
+    } else if (response.status === 200) {
+      flashMessage('success', response.data[0].message);
+    }
+    if (response.status === 401) {
+        flashMessage('error', 'An error occured');
+        logout();
+    }
+  })
+  .catch((error) => {
+    elementClicked.setAttribute('disabled', 'false');
+    console.log(error);
+  });
+
+}
+
 function recordTemplate(currentData) {
   if(user.id == currentData.createdBy) {
     console.log(user.id);
   }
   return  `
   <div class="card">
-  <p class="record-status">Status: ${currentData.status} ${user.isAdmin?'<a href=""><i class="fa fa-fw fa-edit"></i></a>':''}</p> 
+  <p class="record-status">Status: ${currentData.status} ${user.isAdmin?'<a href="#"><i class="fa fa-fw fa-edit"></i></a>':''}</p> 
   ${ currentData.image?` <img class="record-image" src="${currentData.image}"/>`:''}
   <a href="#" class="record-title">${currentData.title}</a>
   ${currentData.comment}
@@ -96,10 +146,21 @@ function recordTemplate(currentData) {
   ${(user.id == currentData.createdBy)?
     `<a href="#" class="rc"><i  onClick="setEdit(event)" data="${currentData.id}" class="fa fa-fw fa-edit "></i></a>`
     :''}
-      ${(user.id == currentData.createdBy)?
+  ${(user.id == currentData.createdBy)?
       `<a href="#" class="rc"><i onClick="deleteRecord(event)"  data="${currentData.id}"  class="fa fa-fw fa-trash"></i></a>`
-      :''}
+    :''}
+  ${(user.isAdmin == true)?
+    `
+    <select class=" input" onchange="changeStatus(event)"  data="${currentData.id}" type=${currentData.type} >
+      <option value="under-investigation" onClick="changeStatus(event)">Under-investigation</option>
+      <option value="draft" selected onClick="changeStatus(event)">Draft</option>
+      <option value="resolved" onClick="changeStatus(event)">Resolved</option>
+      <option value="rejected" onClick="changeStatus(event)">Rejected</option>
+    </select>
+    `
+  :''}
   </div>
  </div>
   `;
 }
+

--- a/UI/single-record.html
+++ b/UI/single-record.html
@@ -15,6 +15,10 @@
             <a href="#" onclick="toggleNav()" class="nav-mobile">☰ menu</a>
         </nav>
     </section>
+    <form id="form">
+       <div id="flash"></div>  
+    </form>
+    
     <section class="records" id="record">
         <div class="container-center">Loading.....</div>
     </section>


### PR DESCRIPTION
**What does this PR do?**
This PR enables an admin to change the status of a record

**Tasks to be completed?**
- show change status list box if the user is an admin
- handle onclick action
- send request on click PATCH
- handle error
- disable button while the request is handled

**How can tthis be manually tested**
- clone the repo
- cd into the directory
- open index.html in a browser
- login as an admin 
- open records.html and select a single record
- edit the record status with the options by selecting the desired status

**Relevant PT stories?**
`163395374`